### PR TITLE
Add support for VSCode's intellisense (and other editors that behave like VSCode), update examples with stronger types, fix a couple of issues with helper types

### DIFF
--- a/example/examples/binary-clock.ts
+++ b/example/examples/binary-clock.ts
@@ -1,7 +1,8 @@
+import { Gadget } from "../../typedefs/functions";
 import { IntRange, WithLedStrip, WithSegmentDisplay } from "../../typedefs/helpers";
 
 // board definition
-type Board = Gadget & WithLedStrip<8> & WithSegmentDisplay<4>;
+type Board = Gadget & WithLedStrip<8> & WithSegmentDisplay<5>;
 declare const gdt: Board;
 
 // helper methods
@@ -17,8 +18,8 @@ const LEDCount = 8;
 const DisplayColor = ColorRGBA(0, 255, 0, 255);
 
 // setup
-for(let i = 0; i < 4; i++) {
-    gdt.SegmentDisplay0.SetDigitColor(i + 1, DisplayColor);
+for(let i = 1; i <= 4; i++) {
+    gdt.SegmentDisplay0.SetDigitColor(i as 1 | 2 | 3 | 4, DisplayColor);
 }
 
 // update loop
@@ -26,7 +27,7 @@ let accum = 0;
 update = () => {
     accum  += gdt.CPU0!.DeltaTime;
     for(let i = 0; i < LEDCount; i++) {
-        gdt.LedStrip0.States[i + 1] = isOn(accum * 2, i + 1 as IntRange<0, 8>);    
+        (gdt.LedStrip0.States[(i + 1 as IntRange<0, 8>)] as boolean) = isOn(accum * 2, i + 1 as IntRange<0, 8>);    
     }
     gdt.SegmentDisplay0.ShowDigit(2, math.floor(accum % 1000 / 100));
     gdt.SegmentDisplay0.ShowDigit(3, math.floor(accum % 100 / 10));

--- a/example/examples/lamp-flipper.ts
+++ b/example/examples/lamp-flipper.ts
@@ -1,4 +1,6 @@
+import { Gadget, MultitoolConnector } from "../../typedefs/functions";
 import { WithLeds } from "../../typedefs/helpers";
+import { PowerButton, Led } from "../../typedefs/types";
 
 const LEDCount = 5;
 type Board = Gadget & WithLeds<typeof LEDCount>;

--- a/example/examples/raytracer.ts
+++ b/example/examples/raytracer.ts
@@ -1,4 +1,6 @@
-import { WithCPU, WithLcd, WithVideoChip } from "../../typedefs/helpers";
+import { Gadget } from "../../typedefs/functions";
+import { IntRange, WithCPU, WithLcd, WithVideoChip } from "../../typedefs/helpers";
+import { VideoChip, vec2 } from "../../typedefs/types";
 
 class Vector {
     constructor(public x: number,
@@ -23,26 +25,29 @@ class Vector {
 }
 
 class ColorTS {
-    constructor(public r: number,
-                public g: number,
-                public b: number) {
-    }
-    static scale(k: number, v: ColorTS) { return new ColorTS(k * v.r, k * v.g, k * v.b); }
-    static plus(v1: ColorTS, v2: ColorTS) { return new ColorTS(v1.r + v2.r, v1.g + v2.g, v1.b + v2.b); }
-    static times(v1: ColorTS, v2: ColorTS) { return new ColorTS(v1.r * v2.r, v1.g * v2.g, v1.b * v2.b); }
-    static white = new ColorTS(1.0, 1.0, 1.0);
-    static grey = new ColorTS(0.5, 0.5, 0.5);
-    static black = new ColorTS(0.0, 0.0, 0.0);
-    static background = ColorTS.black;
-    static defaultColor = ColorTS.black;
-    static toDrawingColor(c: ColorTS) {
-        const legalize = (d: number) => d > 1 ? 1 : d;
-        return {
-            r: Math.floor(legalize(c.r) * 255),
-            g: Math.floor(legalize(c.g) * 255),
-            b: Math.floor(legalize(c.b) * 255)
-        }
-    }
+	constructor(public r: number, public g: number, public b: number) {}
+	static scale(k: number, v: ColorTS) {
+		return new ColorTS(k * v.r, k * v.g, k * v.b);
+	}
+	static plus(v1: ColorTS, v2: ColorTS) {
+		return new ColorTS(v1.r + v2.r, v1.g + v2.g, v1.b + v2.b);
+	}
+	static times(v1: ColorTS, v2: ColorTS) {
+		return new ColorTS(v1.r * v2.r, v1.g * v2.g, v1.b * v2.b);
+	}
+	static white = new ColorTS(1.0, 1.0, 1.0);
+	static grey = new ColorTS(0.5, 0.5, 0.5);
+	static black = new ColorTS(0.0, 0.0, 0.0);
+	static background = ColorTS.black;
+	static defaultColor = ColorTS.black;
+	static toDrawingColor(c: ColorTS) {
+		const legalize = (d: number) => (d > 1 ? 1 : d);
+		return {
+			r: <IntRange<0, 256>>Math.floor(legalize(c.r) * 255),
+			g: <IntRange<0, 256>>Math.floor(legalize(c.g) * 255),
+			b: <IntRange<0, 256>>Math.floor(legalize(c.b) * 255),
+		};
+	}
 }
 
 class Camera {

--- a/typedefs/functions.d.ts
+++ b/typedefs/functions.d.ts
@@ -1,79 +1,95 @@
 /**
  * Imports
  */
-import { IntRange } from "./helpers";
-import { color, ANSIColors, Desk, PowerButton } from "./types";
+import { IntRange } from './helpers';
+import { color, ANSIColors, Desk, PowerButton } from './types';
 
 /*
  * Global Methods
  */
+declare global {
+	/**
+	 * Compose and returns a RGB Color object. Values for the 3 channels are always expressed in the range 0-255.
+	 */
+	function Color(
+		this: void,
+		r: IntRange<0, 256>,
+		g: IntRange<0, 256>,
+		b: IntRange<0, 256>,
+	): color;
+	/**
+	 * Compose and returns a RGB Color object, with Alpha. Values for the 4 channels are always expressed in the range 0-255. Alpha 0 is transparent
+	 */
+	function ColorRGBA(
+		this: void,
+		r: IntRange<0, 256>,
+		g: IntRange<0, 256>,
+		b: IntRange<0, 256>,
+		a: IntRange<0, 256>,
+	): color;
+	/**
+	 * Compose and returns a RGB Color Object, expressing it in HSV values.
+	 * @param h [0-360]
+	 * @param s [0-100]
+	 * @param v [0-100]
+	 */
+	function ColorHSV(
+		this: void,
+		h: IntRange<0, 361>,
+		s: IntRange<0, 101>,
+		v: IntRange<0, 101>,
+	): color;
 
-/**
- * Compose and returns a RGB Color object. Values for the 3 channels are always expressed in the range 0-255.
- */
-declare function Color(this: void, r: IntRange<0, 256>, g: IntRange<0, 256>, b: IntRange<0, 256>): color
-/**
- * Compose and returns a RGB Color object, with Alpha. Values for the 4 channels are always expressed in the range 0-255. Alpha 0 is transparent
- */
-declare function ColorRGBA(this: void, r: IntRange<0, 256>, g: IntRange<0, 256>, b: IntRange<0, 256>, a: IntRange<0, 256>): color
-/**
- * Compose and returns a RGB Color Object, expressing it in HSV values.
- * @param h [0-360] 
- * @param s [0-100]
- * @param v [0-100]
- */
-declare function ColorHSV(this: void, h: IntRange<0, 361>, s: IntRange<0, 101>, v: IntRange<0, 101>): color
+	function log(this: void, message: string): void;
+	function logWarning(this: void, message: string): void;
+	function logError(this: void, message: string): void;
 
+	function write(this: void, text: string): void;
+	function writeLn(this: void, text: string): void;
 
-declare function log(this: void, message: string): void
-declare function logWarning(this: void, message: string): void
-declare function logError(this: void, message: string): void
+	/**
+	 * Use ANSI Colors
+	 */
+	function setFgColor(this: void, colorId: ANSIColors): void;
+	/**
+	 * Use ANSI colors
+	 */
+	function setBgColor(this: void, colorId: ANSIColors): void;
+	function resetFgColor(this: void): void;
+	function resetBgColor(this: void): void;
+	function resetColors(this: void): void;
 
-declare function write(this: void, text: string): void
-declare function writeLn(this: void, text: string): void
+	function setCurorPos(this: void, column: number, line: number): void;
+	function setCurorX(this: void, column: number): void;
+	function setCursorY(this: void, line: number): void;
+	function moveCursorX(this: void, deltaColumn: number): void;
+	function moveCursorY(this: void, deltaLine: number): void;
+	function saveCurosorPos(this: void): void;
+	function restoreCursorPos(this: void): void;
 
-/**
- * Use ANSI Colors
- */
-declare function setFgColor(this: void, colorId: ANSIColors): void
-/**
- * Use ANSI colors
- */
-declare function setBgColor(this: void, colorId: ANSIColors): void
-declare function resetFgColor(this: void): void
-declare function resetBgColor(this: void): void
-declare function resetColors(this: void): void
+	function clear(this: void): void;
+	function clearToEndLine(this: void): void;
 
-declare function setCurorPos(this: void, column: number, line: number): void
-declare function setCurorX(this: void, column: number): void
-declare function setCursorY(this: void, line: number): void
-declare function moveCursorX(this: void, deltaColumn: number): void
-declare function moveCursorY(this: void, deltaLine: number): void
-declare function saveCurosorPos(this: void): void
-declare function restoreCursorPos(this: void): void
+	/*
+	 * Desk Methods
+	 */
+	const desk: Desk;
 
-declare function clear(this: void): void
-declare function clearToEndLine(this: void): void
-
-/*
- * Desk Methods
- */
-declare const desk: Desk
-
-/**
- * Runtime functions
- */
-declare let update: () => void;
+	/**
+	 * Runtime functions
+	 */
+	let update: () => void;
+}
 
 /*
  * Undocumented
  */
 
-type MultitoolConnector = { }
+type MultitoolConnector = {};
 
 type Gadget = {
-    MultitoolConnector: MultitoolConnector,
-    PowerButton: PowerButton,
-    // the following can be any number of components with their name and number attached
-    [k: string]: any
-}
+	MultitoolConnector: MultitoolConnector;
+	PowerButton: PowerButton;
+	// the following can be any number of components with their name and number attached
+	[k: string]: any;
+};

--- a/typedefs/functions.d.ts
+++ b/typedefs/functions.d.ts
@@ -1,3 +1,9 @@
+/**
+ * Imports
+ */
+import { IntRange } from "./helpers";
+import { color, ANSIColors, Desk, PowerButton } from "./types";
+
 /*
  * Global Methods
  */

--- a/typedefs/functions.d.ts
+++ b/typedefs/functions.d.ts
@@ -11,18 +11,18 @@ import { color, ANSIColors, Desk, PowerButton } from "./types";
 /**
  * Compose and returns a RGB Color object. Values for the 3 channels are always expressed in the range 0-255.
  */
-declare function Color(this: void, r: IntRange<0, 255>, g: IntRange<0, 255>, b: IntRange<0, 255>): color
+declare function Color(this: void, r: IntRange<0, 256>, g: IntRange<0, 256>, b: IntRange<0, 256>): color
 /**
  * Compose and returns a RGB Color object, with Alpha. Values for the 4 channels are always expressed in the range 0-255. Alpha 0 is transparent
  */
-declare function ColorRGBA(this: void, r: IntRange<0, 255>, g: IntRange<0, 255>, b: IntRange<0, 255>, a: IntRange<0, 255>): color
+declare function ColorRGBA(this: void, r: IntRange<0, 256>, g: IntRange<0, 256>, b: IntRange<0, 256>, a: IntRange<0, 256>): color
 /**
  * Compose and returns a RGB Color Object, expressing it in HSV values.
  * @param h [0-360] 
  * @param s [0-100]
  * @param v [0-100]
  */
-declare function ColorHSV(this: void, h: IntRange<0, 360>, s: IntRange<0, 100>, v: IntRange<0, 100>): color
+declare function ColorHSV(this: void, h: IntRange<0, 361>, s: IntRange<0, 101>, v: IntRange<0, 101>): color
 
 
 declare function log(this: void, message: string): void

--- a/typedefs/helpers.d.ts
+++ b/typedefs/helpers.d.ts
@@ -1,12 +1,23 @@
+/**
+ * Imports
+ */
+import { ROM, Stick, Keypad, Knob, LedButton, ScreenButton, Slider, Switch, Webcam, Gauge, Lcd, Led, LedMatrix, Speaker, AudioChip, CPU, Decoration, FlashMemory, GamepadChip, KeyboardChip, MagneticConnector, PowerButton, RealityChip, SecurityChip, VideoChip, Wifi, LedStrip, SegmentDisplay } from "./types";
+
 /*
  * Based on IntRange from here:
  * https://stackoverflow.com/a/39495173
  */
-type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] extends N
-  ? Acc[number]
-  : Enumerate<N, [...Acc, Acc['length']]>
+type IntRangeEnumerate<
+	N extends number,
+	Acc extends number[] = [],
+> = Acc['length'] extends N
+	? Acc[number]
+	: IntRangeEnumerate<N, [...Acc, Acc['length']]>;
 
-type IntRange<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>>
+type IntRange<F extends number, T extends number> = Exclude<
+	IntRangeEnumerate<T>,
+	IntRangeEnumerate<F>
+>;
 
 /*
  * From:
@@ -16,7 +27,7 @@ type IntRange<F extends number, T extends number> = Exclude<Enumerate<T>, Enumer
  * An array in a fixed size of `N` of type `T`
  */
 type FixedSizeArray<N extends number, T> = {
-    readonly [k in Enumerate<N>]: T;
+	readonly [k in IntRangeEnumerate<N>]: T;
 } & { length: N };
 
 /**

--- a/typedefs/types.d.ts
+++ b/typedefs/types.d.ts
@@ -373,11 +373,11 @@ type AudioChip = {
     /**
      * Sets the current `volume` for a `channel`, 0-100 range.
      */
-    SetChannelVolume(volume: IntRange<0, 100>, channel: number),
+    SetChannelVolume(volume: IntRange<0, 101>, channel: number),
     /**
      * Gets the current volume for a channel, 0-100 range.
      */
-    GetChannelVolume(volume: number): IntRange<0, 100>,
+    GetChannelVolume(volume: number): IntRange<0, 101>,
     /**
      * Sets the `pitch` for a `channel`. Acts as a multiplier.
      * A value of 1 means the default `pitch` for a sample,

--- a/typedefs/types.d.ts
+++ b/typedefs/types.d.ts
@@ -1,6 +1,11 @@
 /// <reference path="functions.d.ts">
 /// <reference path="helpers.d.ts">
 
+/**
+ * Imports
+ */
+import { ReadOnlyFixedSizeArray, FixedSizeArray, IntRange } from "./helpers";
+
 /*
  * Globals
  */
@@ -157,16 +162,16 @@ type Keypad = {
 type Knob = MovingButton;
 
 type LedButton = ClickButton & {
-    /**
-     * The lit/unlit state of the Led.
-     */
-    LedState: boolean,
-    /**
-     * The color of the Led.
-     */
-    LedColor: Color,
-    Symbol: undefined, // Symbol, the docs describe it, but accessing it is a RuntimeError
-}
+	/**
+	 * The lit/unlit state of the Led.
+	 */
+	LedState: boolean;
+	/**
+	 * The color of the Led.
+	 */
+	LedColor: color;
+	Symbol: undefined; // Symbol, the docs describe it, but accessing it is a RuntimeError
+};
 
 type ScreenButton = ClickButton & {
     /**
@@ -214,19 +219,19 @@ type Gauge = {
 }
 
 type Lcd = {
-    /**
-     * The text to be visualized on the Lcd.
-     */
-    Text: string,
-    /**
-     * Background color for the Lcd.
-     */
-    BgColor: Color,
-    /**
-     * The color for thew displayed text.
-     */
-    TextColor: Color
-}
+	/**
+	 * The text to be visualized on the Lcd.
+	 */
+	Text: string;
+	/**
+	 * Background color for the Lcd.
+	 */
+	BgColor: color;
+	/**
+	 * The color for thew displayed text.
+	 */
+	TextColor: color;
+};
 
 type Led = {
     /**
@@ -967,9 +972,8 @@ type RenderBuffer = {
 
 }
 
-type Code = {
-
-}
+type Code = {}
+type Asset = {}
 
 type AudioSample = {
     SamplesCount: number,
@@ -985,3 +989,31 @@ type Palette = {
 
 }
 
+// Can be any of the components (aka. modules)
+type Module =
+	| Stick
+	| Keypad
+	| Knob
+	| LedButton
+	| ScreenButton
+	| Slider
+	| Switch
+	| Webcam
+	| Gauge
+	| Lcd
+	| Led
+	| LedMatrix
+	| Screen
+	| Speaker
+	| AudioChip
+	| CPU
+	| Decoration
+	| FlashMemory<any>
+	| GamepadChip
+	| MagneticConnector
+	| PowerButton
+	| RealityChip
+	| ROM
+	| SecurityChip
+	| VideoChip
+	| Wifi;

--- a/typedefs/types.d.ts
+++ b/typedefs/types.d.ts
@@ -281,8 +281,8 @@ type SegmentDisplay<N extends number> = {
      * A table that maps the color of all the Leds in the display.
      */
     Colors: FixedSizeArray<N, color>,
-    ShowDigit(groupIndex: IntRange<0, N>,  digit: number),
-    SetDigitColor(groupIndex: IntRange<0, N>, color: color)
+    ShowDigit(groupIndex: IntRange<1, N>,  digit: number),
+    SetDigitColor(groupIndex: IntRange<1, N>, color: color)
 }
 
 /**


### PR DESCRIPTION
Magically available types (not imported by editors) are highly discouraged.  
I added the `Asset` and `Module` types (they weren't added and I'm guessing you missed them because they are valid types in Node.js?)  
I moved global declarations to  `declare global { ... }` so editors can handle those definitions without having to import them.  
In the examples, the `strict` field was turned on (`tsconfig.json`), and there was also a pool of errors due to incorrect usage of the `FixedSizeArray` type. TypeScript also doesn't catch errors related to for loops (such as the one in `binary-clock.ts`, where while `i` was obviously in the boundaries of `1 | 2 | 3 | 4`, but you can't use the `DigitColor` and such with a `number` type).